### PR TITLE
Fixes issue #20: Saving the shortened urls so that they are not lost on closing the tab.

### DIFF
--- a/src/components/URLShortenerForm.css
+++ b/src/components/URLShortenerForm.css
@@ -174,6 +174,19 @@ a {
   margin-right: 2px;
 }
 
+.history{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #0070f3;
+  margin-top: 10px;
+  flex-direction: column;
+}
+
+.shortened{
+  display: block;
+}
+
 @media only screen and (max-width: 550px) {
   .form {
     width: 350px;

--- a/src/components/URLShortenerForm.tsx
+++ b/src/components/URLShortenerForm.tsx
@@ -15,6 +15,7 @@ function URLShortenerForm() {
   const [loading, setloading] = useState(true);
   const [forks, setforks] = useState(0);
   const [stars, setstars] = useState(0);
+  const [savedArr, setSavedArr] = useState<string[]>([""]);
   const [shortUrl, setShortUrl] = useState<{
     shortId: string;
   } | null>(null);
@@ -32,18 +33,30 @@ function URLShortenerForm() {
       });
 
     setShortUrl(result);
+    if(savedArr.length<5)
+    shortUrl&&setSavedArr((oldArray: string[])=>[...oldArray, finalURL]);
+    else
+    shortUrl&&setSavedArr((oldArray: string[]) => {
+      oldArray.shift();
+      oldArray.pop();
+      oldArray.push(finalURL);
+      return oldArray;
+    })
+    localStorage.setItem("savedURLs", JSON.stringify(savedArr));
   }
   var finalURL = `${window.location.origin}/${shortUrl?.shortId}`;
   const text = () => {
     toast.success("Copied!");
   };
 
+  const savedURLs = (savedArr.map(item => <a className="shortened" href={item} key={item} >{item} </a>))
 
   const getForksStarsCount = async () => {
     const { data } = await axios.get(`https://api.github.com/repos/aditya-singh9/url-shotener-frontend-ts`);
     setforks(data.forks_count);
     setstars(data.stargazers_count);
     setloading(false);
+    setSavedArr(()=>localStorage.getItem("savedURLs")?JSON.parse(localStorage.getItem("savedURLs")||""):[""]);
   };
   useEffect(() => {
     getForksStarsCount();
@@ -136,6 +149,10 @@ function URLShortenerForm() {
               </CopyToClipboard>
             </div>
           )}
+          <div className="history">
+            <p>Previously shortened URLs:</p>
+            {savedURLs}
+          </div>
           <div className="name-div">
             <p className="name">
               Crafted by


### PR DESCRIPTION
Closes the issue #20 
Added the functionality to save the shortened links using localStorage.
The resulting page is responsive and fits the initial theme. The saved URL list doesn't go beyond 5 so as to not let the page get cluttered. Screenshots attached below:
![Screenshot_20221002_170325](https://user-images.githubusercontent.com/95919665/193452848-f3a1dfce-9175-4573-8038-6d00aad9fc6f.png)

On mobile:
![Screenshot_20221002_170353](https://user-images.githubusercontent.com/95919665/193452857-fe1fba8b-d675-429b-b3a9-e15d6a38816f.png)

Fixed merge conflicts :D